### PR TITLE
Read saved MAC address from non-volatile storage

### DIFF
--- a/VAIO_Code/lib/ds4_control/ds4_control.cpp
+++ b/VAIO_Code/lib/ds4_control/ds4_control.cpp
@@ -1,6 +1,12 @@
 #include <ds4_control.h>
 
 ps4Controller DS4Control::ps4;
+Preferences DS4Control::preferences;
+
+void DS4Control::initializePreferences()
+{
+    preferences.begin(MAC_ADDR_STORAGE_NAMESPACE, false);
+}
 
 void DS4Control::vTaskDS4Control(void *pvParamaters)
 {

--- a/VAIO_Code/lib/ds4_control/ds4_control.cpp
+++ b/VAIO_Code/lib/ds4_control/ds4_control.cpp
@@ -2,9 +2,9 @@
 
 ps4Controller DS4Control::ps4;
 
-void DS4Control::vTaskDS4Control(void *paramater)
+void DS4Control::vTaskDS4Control(void *pvParamaters)
 {
-    while (1)
+    while (true)
     {
         int yAxisValue{(ps4.data.analog.stick.ly)};
         int xAxisValue{(ps4.data.analog.stick.rx)};
@@ -69,7 +69,4 @@ void DS4Control::rotateMotor(int rightMotorSpeed, int leftMotorSpeed)
         digitalWrite(motorLeftPin1, LOW);
         digitalWrite(motorLeftPin2, LOW);
     }
-
-    // Set Motor Speeds
-    // To-Do
 }

--- a/VAIO_Code/lib/ds4_control/ds4_control.h
+++ b/VAIO_Code/lib/ds4_control/ds4_control.h
@@ -5,12 +5,15 @@
 #include "ps4Controller.h"
 #include "constants.h"
 #include "pin.h"
+#include "Preferences.h"
 
 class DS4Control
 {
 public:
     static ps4Controller ps4;
+    static Preferences preferences;
 
+    static void initializePreferences();
     static void vTaskDS4Control(void *pvParameters);
     static void onConnect();
     static void onDisconnect();

--- a/VAIO_Code/lib/interface/constants.h
+++ b/VAIO_Code/lib/interface/constants.h
@@ -27,4 +27,7 @@ static const IPAddress LOCAL_IP(192, 168, 1, 1);
 static const IPAddress GATEWAY(192, 168, 1, 1);
 static const IPAddress SUBNET(255, 255, 255, 0);
 
+// Used NVS Namespace for DS4 MAC Address
+static const char *MAC_ADDR_STORAGE_NAMESPACE = "DS4-NVS";
+
 #endif

--- a/VAIO_Code/lib/master_control/master_control.cpp
+++ b/VAIO_Code/lib/master_control/master_control.cpp
@@ -48,6 +48,10 @@ void MasterControl::setControlMode(ControlState mode)
     xTaskCreatePinnedToCore(GyroControl::vTaskGestureControl, "Gyro Control", STACK_SIZE, NULL, 1, &controlTaskHandle, 0);
     break;
   case ControlState::DS4_CONTROL:
+    // Stop the current task
+    vTaskDelete(controlTaskHandle);
+    // Start the DS4 control task
+    xTaskCreatePinnedToCore(DS4Control::vTaskDS4Control, "DS4 Control", 2 * STACK_SIZE, NULL, 1, &controlTaskHandle, 0);
     break;
   default:
     // Handle unknown control mode
@@ -66,6 +70,11 @@ void MasterControl::handleButtonPress(const uint8_t *data)
   else if (data[0] == 0x02)
   { // Button press data for switching to auto control
     setControlMode(ControlState::AUTO_CONTROL);
+  }
+  else if (data[0] == 0x03)
+  {
+    // Button press data for switching to DS4 control
+    setControlMode(ControlState::DS4_CONTROL);
   }
 }
 

--- a/VAIO_Code/lib/master_control/master_control.h
+++ b/VAIO_Code/lib/master_control/master_control.h
@@ -6,25 +6,27 @@
 #include "freertos/task.h"
 #include "auto_control.h"
 #include "gyro_control.h"
+#include "ds4_control.h"
 
 // Define ENUM for control states
-enum class ControlState {
+enum class ControlState
+{
   AUTO_CONTROL,
   GYRO_CONTROL,
   DS4_CONTROL,
 };
 
-class MasterControl{
+class MasterControl
+{
 public:
-    static ControlState currentControlMode;
-    static TaskHandle_t controlTaskHandle;
-    
-    static void init();
-    static void setControlMode(ControlState mode);
-    static void handleButtonPress(const uint8_t* data);
-    static void handleVoiceCommand(const uint8_t* data);
-    static void ESPNOW_OnDataReceive(const uint8_t * mac, const uint8_t *incomingData, int len);
+  static ControlState currentControlMode;
+  static TaskHandle_t controlTaskHandle;
 
+  static void init();
+  static void setControlMode(ControlState mode);
+  static void handleButtonPress(const uint8_t *data);
+  static void handleVoiceCommand(const uint8_t *data);
+  static void ESPNOW_OnDataReceive(const uint8_t *mac, const uint8_t *incomingData, int len);
 };
 
 #endif

--- a/VAIO_Code/lib/setup/setup.cpp
+++ b/VAIO_Code/lib/setup/setup.cpp
@@ -72,7 +72,23 @@ void Setup::Servo()
 
 void Setup::DS4()
 {
-  DS4Control::ps4.begin("d0:27:88:51:4c:50");
+  Preferences p;
+  p.begin(MAC_ADDR_STORAGE_NAMESPACE, false);
+
+  // For now, hardcode default value and emulate user previously sending MAC address
+  // To-Do --> Remove default value with empty string and handle empty MAC address value
+  const char *btmac = p.getString("btmac", "d0:27:88:51:4c:50").c_str();
+
+  while (btmac == "")
+  {
+    Serial.println("MAC address fetch error!");
+    delay(3000);
+  }
+
+  p.end();
+
+  // Connect
+  DS4Control::ps4.begin(btmac);
 
   while (!DS4Control::ps4.isConnected())
   {

--- a/VAIO_Code/lib/setup/setup.cpp
+++ b/VAIO_Code/lib/setup/setup.cpp
@@ -72,12 +72,11 @@ void Setup::Servo()
 
 void Setup::DS4()
 {
-  Preferences p;
-  p.begin(MAC_ADDR_STORAGE_NAMESPACE, false);
+  DS4Control::initializePreferences();
 
   // For now, hardcode default value and emulate user previously sending MAC address
   // To-Do --> Remove default value with empty string and handle empty MAC address value
-  const char *btmac = p.getString("btmac", "d0:27:88:51:4c:50").c_str();
+  const char *btmac = DS4Control::preferences.getString("btmac", "d0:27:88:51:4c:50").c_str();
 
   while (btmac == "")
   {
@@ -85,7 +84,7 @@ void Setup::DS4()
     delay(3000);
   }
 
-  p.end();
+  DS4Control::preferences.end();
 
   // Connect
   DS4Control::ps4.begin(btmac);

--- a/VAIO_Code/lib/setup/setup.h
+++ b/VAIO_Code/lib/setup/setup.h
@@ -11,6 +11,7 @@
 #include <ESPmDNS.h>
 #include <pin.h>
 #include <ds4_control.h>
+#include <Preferences.h>
 
 class Setup
 {

--- a/VAIO_Code/lib/setup/setup.h
+++ b/VAIO_Code/lib/setup/setup.h
@@ -11,7 +11,6 @@
 #include <ESPmDNS.h>
 #include <pin.h>
 #include <ds4_control.h>
-#include <Preferences.h>
 
 class Setup
 {

--- a/VAIO_Code/src/main.cpp
+++ b/VAIO_Code/src/main.cpp
@@ -1,7 +1,5 @@
-
 #include <Arduino.h>
 #include <setup.h>
-#include <ds4_control.h>
 
 void setup()
 {
@@ -21,4 +19,5 @@ void setup()
 
 void loop()
 {
+  // Handled by FreeRTOS
 }


### PR DESCRIPTION
## Overview
Added support for storing DS4 MAC address in NVS storage so later on, user (presumably from a 3rd party application) can send their custom MAC address (for changing controller) to the ESP32 and the ESP32 will store it to NVS. NVS storage namespace will persist throughout ESP32 lifetime, by the way.

The point is, when setting up the first time, the ESP32 will check its internal non-volatile storage (NVS) for previously saved MAC address. If it doesn't exist, use a dummy value / default value. Later on, when user connects a new controller, that controller's MAC address will be stored in the NVS. The data is saved as key-value pair in NVS's namespace called `DS4-NVS` that is instantiated `constants.h`. The key inside the namespace is `btmac`.

## Code Review
### Changed constants.h:
```C++
// Used NVS Namespace for DS4 MAC Address
static const char *MAC_ADDR_STORAGE_NAMESPACE = "DS4-NVS";
```

### Changed Setup::DS4()
```C++
DS4Control::initializePreferences();

// For now, hardcode default value and emulate user previously sending MAC address
// To-Do --> Remove default value with empty string and handle empty MAC address value
const char *btmac = DS4Control::preferences.getString("btmac", "d0:27:88:51:4c:50").c_str();

while (btmac == "")
{
  Serial.println("MAC address fetch error!");
  delay(3000);
}

DS4Control::preferences.end();

// Connect
DS4Control::ps4.begin(btmac);
```

### Previous Setup::DS4()
```C++
DS4Control::ps4.begin("d0:27:88:51:4c:50");
```